### PR TITLE
Fix: Fix deathlink message making die instantly not work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin
 /obj
 .vs
+/.idea

--- a/AP Core Scripts/DeathLinkPatch.cs
+++ b/AP Core Scripts/DeathLinkPatch.cs
@@ -27,7 +27,11 @@ namespace ACTAP
             if (Plugin.connection.session != null)
             {
                 string msgBody = "";
-                if (killEvent.source.GetComponent<Boss>() != null)
+                if (killEvent.source == null)
+                {
+                    msgBody = "died";
+                }
+                else if (killEvent.source.GetComponent<Boss>() != null)
                 {
                     string killer = killEvent.source.GetComponent<Boss>().bossName;
                     killer = killer.Replace("Enemy_", "");


### PR DESCRIPTION
Fixes a null exception error when trying to use the "Die Instantly" button with Deathlink enabled.